### PR TITLE
Backport jdbc driver patches

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
@@ -1003,7 +1003,9 @@ public class CUBRIDConnection implements Connection {
 
 	/* JDK 1.6 */
 	public boolean isValid(int arg0) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		if (u_con == null || is_closed) return false;
+
+		return !u_con.isClosed();
 	}
 
 	/* JDK 1.6 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -1954,7 +1954,7 @@ public class CUBRIDResultSet implements ResultSet {
 
 	/* JDK 1.6 */
 	public boolean isClosed() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw is_closed;
 	}
 
 	/* JDK 1.6 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
@@ -1081,7 +1081,7 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
 
 	/* JDK 1.6 */
 	public boolean isClosed() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		return is_closed;
 	}
 
 	/* JDK 1.6 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -780,7 +780,7 @@ public class CUBRIDStatement implements Statement {
 
 	/* JDK 1.6 */
 	public boolean isClosed() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		return is_closed;
 	}
 
 	/* JDK 1.6 */


### PR DESCRIPTION
- implement ```CUBRIDConnection#isValid(int)```
  - https://github.com/CUBRID/cubrid/commit/483fb30492b00717786bf105091364ea323032b3
- implement ```CUBRIDResultSet#isClosed```, ```CUBRIDResultSetWithoutQuery#isClosed```
  - https://github.com/CUBRID/cubrid/commit/488b182378a9d18e3f129d21cfaa7238ef5fb863
- implement ```CUBRIDStatement#isClosed```
  - https://github.com/CUBRID/cubrid/commit/2d1d7264dbef165ff74447e9981aeaf60f2083e3
