### PR TITLE
[CBRD-21446] Installing CUBRID with zip on Windows, cubrid server start fail.

### DIFF
--- a/contrib/windows_scripts/cubrid_env.bat
+++ b/contrib/windows_scripts/cubrid_env.bat
@@ -1,0 +1,23 @@
+@echo off
+rem batch script for CUBRID Environments, (window services, registry)
+
+rem LOADING CUBRID Environments
+echo Setting CUBRID Environments
+
+
+set CUBRID "C:\CUBRID"
+set CUBRID_DATABASES "%CUBRID%\DATABASES"
+
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\cmserver" /v "ROOT_PATH" /t REG_SZ /d "%CUBRID%\\" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\cmserver" /v "Version" /t REG_SZ /d "2.1.1" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\CUBRID" /v "ROOT_PATH" /t REG_SZ /d "%CUBRID%\\" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\CUBRID" /v "Version" /t REG_SZ /d "6.0.1" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\CUBRID" /v "Patch" /t REG_SZ /d "8" /f
+
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "CUBRID" /t REG_SZ /d "%CUBRID%\\" /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "CUBRID_DATABASES" /t REG_SZ /d "%CUBRID%\databases" /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "Path" /t REG_SZ /d "%CUBRID%\bin;%PATH%" /f
+
+echo %CUBRID%
+echo %CUBRID_DATABASES%
+echo %Path%

--- a/win/install/install.bat
+++ b/win/install/install.bat
@@ -155,6 +155,9 @@ copy %SRC_DIR%\..\..\..\locales\data\codepages\*.txt %DEST_DIR%\locales\data\cod
 xcopy %SRC_DIR%\..\..\..\locales\loclib_win_%3 %DEST_DIR%\locales\loclib /e /c /i /f /r /y
 copy %SRC_DIR%\..\..\..\src\base\locale_lib_common.h %DEST_DIR%\locales\loclib\locale_lib_common.h /y
 copy %SRC_DIR%\..\..\..\locales\make_locale_%3.bat %DEST_DIR%\bin\make_locale.bat /y
+mkdir %DEST_DIR%\shard
+mkdir %DEST_DIR%\shard\windows_scripts
+copy %SRC_DIR%\..\..\..\contrib\windows_scripts\*.bat %DEST_DIR%\shard\windows_scripts
 
 echo on
 for %%f in (%MSG_EN_US_DIR%,%MSG_EN_US_UTF8_DIR%,%MSG_EUCKR_DIR%,%MSG_UTFKR_DIR%,%MSG_TR_UTF8_DIR%) do %GENCAT% %%f\csql.cat %%f\csql.msg


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21446

When installing CUBRID as a zip file on Windows, execution may fail because there is no DLL,  environment variables or registry settings are not set.
In this case, DLL installation, environment variables, and registry settings are required.