### PR TITLE
[RND-2027] Prevents exceeding the length of the tuple when accessing a field in the qfile_make_sort_key function

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3867,6 +3867,7 @@ qfile_make_sort_key (THREAD_ENTRY * thread_p, SORTKEY_INFO * key_info_p,
 	  /* safe guard: access to a position exceeding length */
 	  if (length > tuple_length)
 	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	      return SORT_ERROR_OCCURRED;
 	    }
 

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3810,7 +3810,7 @@ qfile_make_sort_key (THREAD_ENTRY * thread_p, SORTKEY_INFO * key_info_p,
 		     RECDES * key_record_p, QFILE_LIST_SCAN_ID * input_scan_p,
 		     QFILE_TUPLE_RECORD * tuple_record_p)
 {
-  int i, nkeys, length;
+  int i, nkeys, length, tuple_length;
   SORT_REC *sort_record_p;
   char *data;
   SCAN_CODE scan_status;
@@ -3848,6 +3848,9 @@ qfile_make_sort_key (THREAD_ENTRY * thread_p, SORTKEY_INFO * key_info_p,
 	  sort_record_p->s.original.offset = input_scan_p->curr_offset;
 	}
 
+      /* safe guard: access to a position exceeding length */
+      tuple_length = QFILE_GET_TUPLE_LENGTH (tuple_record_p->tpl);
+
       /* STEP 2: build body */
       for (i = 0; i < nkeys; i++)
 	{
@@ -3860,6 +3863,12 @@ qfile_make_sort_key (THREAD_ENTRY * thread_p, SORTKEY_INFO * key_info_p,
 	      V_BOUND) ? QFILE_GET_TUPLE_VALUE_LENGTH (field_data) : 0);
 
 	  length += QFILE_TUPLE_VALUE_HEADER_SIZE + field_length;
+
+	  /* safe guard: access to a position exceeding length */
+	  if (length > tuple_length)
+	    {
+	      return SORT_ERROR_OCCURRED;
+	    }
 
 	  if (length <= key_record_p->area_size)
 	    {


### PR DESCRIPTION
http://jira.cubrid.com/browse/RND-2027

Prevents exceeding the length of the tuple when accessing a field in the qfile_make_sort_key function.

```
drop table if exists t1;
create table t1 (c1 varchar primary key, c2 varchar, c3 int);
create index i1 on t1 (c2);
insert into t1 values ('a', null, 1);

/* (gdb) break ../src/query/list_file.c:3868
 * (gdb) info breakpoints

Num     Type           Disp Enb Address            What
1       breakpoint     keep y   0x00007fa3d8bce5ab in qfile_make_sort_key at ../src/query/list_file.c:3868

*/

select c1, row_number() over (order by c3)
from t1
start with c1 = 'a'
connect by prior c2 = c1;

/* (gdb) set length = 121
 * (gdb) continue         */

/* ERROR: Internal system failure: no more specific information is available. */
```