### PR TITLE
[CBRD-25145] Problem of removing expr from sort spec of analytic function when statement pooling

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2549,6 +2549,7 @@ struct pt_showstmt_info
 struct pt_sort_spec_info
 {
   PT_NODE *expr;		/* PT_EXPR, PT_VALUE, PT_NAME */
+  PT_NODE *prev_expr;		/* PT_EXPR, PT_VALUE, PT_NAME */
   QFILE_TUPLE_VALUE_POSITION pos_descr;	/* Value position descriptor */
   PT_MISC_TYPE asc_or_desc;	/* enum value will be PT_ASC or PT_DESC    */
   PT_MISC_TYPE nulls_first_or_last;	/* enum value will be

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -15293,6 +15293,7 @@ pt_apply_sort_spec (PARSER_CONTEXT * parser, PT_NODE * p,
 		    PT_NODE_FUNCTION g, void *arg)
 {
   p->info.sort_spec.expr = g (parser, p->info.sort_spec.expr, arg);
+  p->info.sort_spec.prev_expr = g (parser, p->info.sort_spec.prev_expr, arg);
   return p;
 }
 
@@ -15305,6 +15306,7 @@ static PT_NODE *
 pt_init_sort_spec (PT_NODE * p)
 {
   p->info.sort_spec.expr = 0;
+  p->info.sort_spec.prev_expr = 0;
   p->info.sort_spec.pos_descr.pos_no = 0;
   p->info.sort_spec.pos_descr.dom = NULL;
   p->info.sort_spec.asc_or_desc = PT_ASC;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25145

backport CUBRID/cubrid#4861

When creating xasl with a rewrite query, the expression pointed to by sort_spec changed to PT_VALUE cannot be found.
In to-be, the previous expression is backed up in prev_expr of sort_spec.