### PR TITLE
[CBRD-25145] Problem of removing expr from sort spec of analytic function when statement pooling

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2146,6 +2146,8 @@ struct pt_function_info
     PT_NODE *order_by;		/* ordering PT_SORT_SPEC list */
     PT_NODE *default_value;	/* LEAD/LAG function default value */
     PT_NODE *offset;		/* LEAD/LAG/NTH_VALUE function offset */
+    PT_NODE *expanded_list;	/* reserved list when expand partition_by/order_by */
+    bool adjusted;		/* whether the partition_by/order_by be adjusted and expanded */
     bool from_last;		/* determines whether the calculation begins at the last or first row */
     bool ignore_nulls;		/* determines whether the calculation eliminate or includes null values */
     bool is_analytic;		/* is analytic clause */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12236,6 +12236,8 @@ pt_apply_function (PARSER_CONTEXT * parser, PT_NODE * p,
 	g (parser, p->info.function.analytic.offset, arg);
       p->info.function.analytic.default_value =
 	g (parser, p->info.function.analytic.default_value, arg);
+      p->info.function.analytic.expanded_list =
+	g (parser, p->info.function.analytic.expanded_list, arg);
     }
   return p;
 }
@@ -12257,6 +12259,8 @@ pt_init_function (PT_NODE * p)
   p->info.function.analytic.partition_by = NULL;
   p->info.function.analytic.order_by = NULL;
   p->info.function.analytic.default_value = NULL;
+  p->info.function.analytic.expanded_list = NULL;
+  p->info.function.analytic.adjusted = false;
   p->info.function.analytic.offset = NULL;
   p->info.function.analytic.from_last = false;
   p->info.function.analytic.ignore_nulls = false;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -23201,6 +23201,8 @@ pt_expand_analytic_node (PARSER_CONTEXT * parser, PT_NODE * node,
 			 PT_NODE * select_list)
 {
   PT_NODE *spec, *arg, *ptr;
+  PT_NODE *old_ex_list = NULL, *new_ex_list = NULL;
+  PT_NODE *last_node = NULL;
   bool visited_part = false;
 
   if (parser == NULL)
@@ -23287,6 +23289,34 @@ pt_expand_analytic_node (PARSER_CONTEXT * parser, PT_NODE * node,
       (void) parser_append_node (node->info.function.analytic.default_value,
 				 select_list);
       node->info.function.analytic.default_value = ptr;
+    }
+
+  if (node->info.function.analytic.adjusted)
+    {
+      /* if old expanded list existed, append to the select list */
+      if (node->info.function.analytic.expanded_list != NULL)
+	{
+	  old_ex_list =
+	    parser_copy_tree_list (parser,
+				   node->info.function.analytic.
+				   expanded_list);
+	  if (old_ex_list == NULL)
+	    {
+	      PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC,
+			 MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+	      return NULL;
+	    }
+	  (void) parser_append_node (old_ex_list, select_list);
+	}
+
+      return node;
+    }
+
+  /* get the last node of select_list */
+  last_node = select_list;
+  while (last_node->next != NULL)
+    {
+      last_node = last_node->next;
     }
 
   /* walk order list and resolve nodes that were not found in select list */
@@ -23390,6 +23420,25 @@ pt_expand_analytic_node (PARSER_CONTEXT * parser, PT_NODE * node,
 	}
     }
 
+  /* Since the partition_by and order_by may be replaced as pt_value,
+   * the old expr should be reserved. */
+  if (last_node->next != NULL)
+    {
+      new_ex_list = parser_copy_tree_list (parser, last_node->next);
+      if (new_ex_list == NULL)
+	{
+	  PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC,
+		     MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+	  return NULL;
+	}
+
+      assert (node->info.function.analytic.expanded_list == NULL);
+      node->info.function.analytic.expanded_list = new_ex_list;
+    }
+
+  /* set the analytic has been adjusted and expanded */
+  node->info.function.analytic.adjusted = true;
+
   /* all ok */
   return node;
 }
@@ -23457,6 +23506,12 @@ pt_adjust_analytic_sort_specs (PARSER_CONTEXT * parser, PT_NODE * node,
     }
 
   if (node == NULL || !PT_IS_ANALYTIC_NODE (node))
+    {
+      /* nothing to do */
+      return;
+    }
+
+  if (node->info.function.analytic.adjusted)
     {
       /* nothing to do */
       return;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25145
http://jira.cubrid.org/browse/CUBRIDSUS-16864

backport https://github.com/CUBRID/cubrid/commit/5fe99a00ba5a273bd24e5afaf13150226eb0c8bf