### PR TITLE
[CBRD-24130] backport: Exclude view related STMTs in object file of unloaddb #3259

### DIFF
--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -1040,7 +1040,8 @@ extractobjects (const char *exec_name, int nthreads, int sampling_records, bool 
   for (i = 0; i < class_table->num; i++)
     {
       if (WS_MARKED_DELETED (class_table->mops[i]) ||
-	  class_table->mops[i] == sm_Root_class_mop)
+	  class_table->mops[i] == sm_Root_class_mop ||
+          db_is_vclass (class_table->mops[i]))
 	{
 	  continue;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24130

* backport   #3259

- unloaddb의 object 결과 파일에 view 관련 정보를 출력하지 않도록 함.